### PR TITLE
fw/b: Prevent trying to enable hw offload for tethering via VPN upstr…

### DIFF
--- a/services/core/java/com/android/server/connectivity/Tethering.java
+++ b/services/core/java/com/android/server/connectivity/Tethering.java
@@ -40,6 +40,7 @@ import static android.net.ConnectivityManager.TETHERING_BLUETOOTH;
 import static android.net.ConnectivityManager.TETHERING_INVALID;
 import static android.net.ConnectivityManager.TETHERING_USB;
 import static android.net.ConnectivityManager.TETHERING_WIFI;
+import static android.net.NetworkCapabilities.NET_CAPABILITY_NOT_VPN;
 import static android.net.NetworkCapabilities.TRANSPORT_CELLULAR;
 import static android.net.wifi.WifiManager.EXTRA_WIFI_AP_INTERFACE_NAME;
 import static android.net.wifi.WifiManager.EXTRA_WIFI_AP_MODE;
@@ -1763,6 +1764,12 @@ public class Tethering extends BaseNetworkObserver {
             }
 
             public void updateUpstreamNetworkState(NetworkState ns) {
+                // Disable hw offload on vpn upstream interfaces.
+                // setUpstreamLinkProperties() interprets null as disable.
+                if (ns != null && ns.networkCapabilities != null
+                        && !ns.networkCapabilities.hasCapability(NET_CAPABILITY_NOT_VPN)) {
+                    ns = null;
+                }
                 mOffloadController.setUpstreamLinkProperties(
                         (ns != null) ? ns.linkProperties : null);
             }


### PR DESCRIPTION
…eams

* Tethering via VPN upstream requires a sw path.

* hw offload setup happened to be being disabled anyway owing to a fail
  return code from setDataLimit().  However, it was causing offload to be
  disabled entirely (until next hotspot off / on event).

* Gracefully skip hw offload for vpn upstreams so that it is automatically
  used again when a vpn is disconnected.

Change-Id: I4df13f02889305560903b7b1e919eedc7af78c07